### PR TITLE
修改会战和活动日期格式化字符串中的日、分、秒，解决国服数据库数据解析崩溃问题

### DIFF
--- a/app/src/main/java/com/github/malitsplus/shizurunotes/db/MasterHatsune.kt
+++ b/app/src/main/java/com/github/malitsplus/shizurunotes/db/MasterHatsune.kt
@@ -10,7 +10,7 @@ import java.time.format.DateTimeFormatter
 class MasterHatsune {
     fun getHatsune(): MutableList<HatsuneStage> {
         val hatsuneStageList = mutableListOf<HatsuneStage>()
-        val formatter = DateTimeFormatter.ofPattern("yyyy/M/dd H:mm:ss")
+        val formatter = DateTimeFormatter.ofPattern("yyyy/M/d H:m:s")
         DBHelper.get().getHatsuneSchedule(null)?.forEach { schedule ->
             val hatsuneStage = HatsuneStage(
                 schedule.event_id,

--- a/app/src/main/java/com/github/malitsplus/shizurunotes/db/RawClanBattlePeriod.java
+++ b/app/src/main/java/com/github/malitsplus/shizurunotes/db/RawClanBattlePeriod.java
@@ -12,7 +12,7 @@ public class RawClanBattlePeriod {
     public String end_time;
 
     public ClanBattlePeriod transToClanBattlePeriod(){
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/M/dd H:mm:ss");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/M/d H:m:s");
         return new ClanBattlePeriod(
                 clan_battle_id,
                 LocalDateTime.parse(start_time, formatter),


### PR DESCRIPTION
修改会战和活动日期格式化字符串中的日、分、秒，解决国服数据库数据解析崩溃问题