### PR TITLE
Added a backup API endpoint

### DIFF
--- a/app/src/main/java/com/github/malitsplus/shizurunotes/common/App.kt
+++ b/app/src/main/java/com/github/malitsplus/shizurunotes/common/App.kt
@@ -59,14 +59,14 @@ class App : Application() {
             "jp" -> {
                 Statics.DB_FILE_NAME = Statics.DB_FILE_NAME_JP
                 Statics.DB_FILE_NAME_COMPRESSED = Statics.DB_FILE_NAME_COMPRESSED_JP
-                Statics.LATEST_VERSION_URL = Statics.LATEST_VERSION_URL_JP
-                Statics.DB_FILE_URL = Statics.DB_FILE_URL_JP
+                Statics.LATEST_VERSION_URL = Statics.BACKUP_LATEST_VERSION_URL_JP
+                Statics.DB_FILE_URL = Statics.BACKUP_DB_FILE_URL_JP
             }
             "cn" -> {
                 Statics.DB_FILE_NAME = Statics.DB_FILE_NAME_CN
                 Statics.DB_FILE_NAME_COMPRESSED = Statics.DB_FILE_NAME_COMPRESSED_CN
-                Statics.LATEST_VERSION_URL = Statics.LATEST_VERSION_URL_CN
-                Statics.DB_FILE_URL = Statics.DB_FILE_URL_CN
+                Statics.LATEST_VERSION_URL = Statics.BACKUP_LATEST_VERSION_URL_CN
+                Statics.DB_FILE_URL = Statics.BACKUP_DB_FILE_URL_CN
             }
         }
     }

--- a/app/src/main/java/com/github/malitsplus/shizurunotes/common/Statics.java
+++ b/app/src/main/java/com/github/malitsplus/shizurunotes/common/Statics.java
@@ -3,6 +3,7 @@ package com.github.malitsplus.shizurunotes.common;
 public class Statics {
     //  API URL
     public static final String API_URL = "https://redive.estertion.win";
+    public static final String BACKUP_API_URL = "https://wthee.xyz";
 
     //  database string for use
     public static String DB_FILE_NAME_COMPRESSED = "redive_jp.db.br";
@@ -14,13 +15,17 @@ public class Statics {
     public static final String DB_FILE_NAME_COMPRESSED_JP = "redive_jp.db.br";
     public static final String DB_FILE_NAME_JP = "redive_jp.db";
     public static final String LATEST_VERSION_URL_JP = API_URL + "/last_version_jp.json";
+    public static final String BACKUP_LATEST_VERSION_URL_JP = BACKUP_API_URL + "/pcr/api/v1/db/info/v2";
     public static final String DB_FILE_URL_JP = API_URL + "/db/" + DB_FILE_NAME_COMPRESSED_JP;
+    public static final String BACKUP_DB_FILE_URL_JP = BACKUP_API_URL + "/db/" + DB_FILE_NAME_COMPRESSED_JP;
 
     //  CN database
     public static final String DB_FILE_NAME_COMPRESSED_CN = "redive_cn.db.br";
     public static final String DB_FILE_NAME_CN = "redive_cn.db";
     public static final String LATEST_VERSION_URL_CN = API_URL + "/last_version_cn.json";
+    public static final String BACKUP_LATEST_VERSION_URL_CN = BACKUP_API_URL + "/pcr/api/v1/db/info/v2";
     public static final String DB_FILE_URL_CN = API_URL + "/db/" + DB_FILE_NAME_COMPRESSED_CN;
+    public static final String BACKUP_DB_FILE_URL_CN = BACKUP_API_URL + "/db/" + DB_FILE_NAME_COMPRESSED_CN;
 
     //  Resource URL
     public static final String IMAGE_URL = API_URL + "/card/full/%d.webp@h300";


### PR DESCRIPTION
As of truthversion `10053000`, Priconne has obfuscated their database table and column names (https://x.com/_Todo_Kirin/status/1746794572133392689?s=20), which just breaks all the SQL queries. 

Currently, estertion's database API is still in the hashed version, but [wthee's](https://github.com/wthee/pcr-tool-sql-diff) seems to have a work around for it (which is still temporary as it is comparing the readable version of the database with the hashed one), so I have added their API endpoints as a backup for the time being. The database that's broken is the `jp` database, but since I thought that it would add a conditional on `UpdateManager` if I only changed the `jp` endpoints, I also changed the `cn` database endpoint. 